### PR TITLE
:rocket: fix(CAJU_MAIN): release develop - fix NODE_VERSION + migrar CI para pnpm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,24 +14,29 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
+          cache: 'pnpm'
 
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
-      - name: Type check
-        run: npm run lint
+      - name: Lint
+        run: pnpm run lint
 
       - name: Build
-        run: npm run build
+        run: pnpm run build
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
           name: dist
-          path: dist/
+          path: .next/
           retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,22 +13,27 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
+          cache: 'pnpm'
 
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Build
-        run: npm run build
+        run: pnpm run build
 
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
-          files: dist/**
+          files: .next/**/*
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
   publish = ".next"
 
 [build.environment]
-  NODE_VERSION = "18.17.0"
+  NODE_VERSION = "18.20.0"
 
 [[plugins]]
   package = "@netlify/plugin-nextjs"


### PR DESCRIPTION
## 🚀 Release: Fix Netlify deploy + GitHub Actions pnpm

### Descricao

Release da branch `develop` para `main` com correcoes criticas para deploy:

1. **NODE_VERSION** atualizado de `18.17.0` para `18.20.0` (requisito Next.js 15)
2. **GitHub Actions** migrados de `npm` para `pnpm` (lock file correto)

### Tipo de Mudanca

- [x] 🐛 Bug fix (correcao de problema existente)

### Mudancas Realizadas

| Arquivo | Mudanca |
|---------|---------|
| `netlify.toml` | `NODE_VERSION`: `18.17.0` → `18.20.0` |
| `.github/workflows/ci.yml` | Migrado npm → pnpm |
| `.github/workflows/release.yml` | Migrado npm → pnpm |

### Detalhes GitHub Actions

- Adicionado `pnpm/action-setup@v4` em ambos workflows
- `cache: 'npm'` → `cache: 'pnpm'`
- `npm ci` → `pnpm install --frozen-lockfile`
- `npm run` → `pnpm run`
- Artifact path `dist/` → `.next/` (Next.js App Router)

### Commits Incluidos

```
f6f0edc :arrow_up: fix(CAJU_NETLIFY): atualizar NODE_VERSION para 18.20.0 (requisito Next.js 15)
7327aa1 :arrow_up: merge(fix/netlify-404-deploy) → develop
9b7ea89 :wrench: fix(CAJU_CI): migrar GitHub Actions de npm para pnpm
```

### Como Testar

1. Fazer merge deste PR na `main`
2. Netlify: build completa sem erros de Node.js version
3. GitHub Actions: CI passa sem erro de lock file
4. Site carrega sem 404

### Checklist

- [x] Mudancas verificadas
- [x] Nenhum breaking change
- [x] Commits seguem Gitmoji

---

> *"Agora sim — pnpm no CI, pnpm no Netlify, pnpm em todo lugar."*
