### PR TITLE
fix: update Node version for Netlify CI + add deploy badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # 🥜 CajuScript
 
+[![Netlify Status](https://api.netlify.com/api/v1/badges/4f784f0c-a16d-4fb2-9308-ea8b2aabe388/deploy-status)](https://app.netlify.com/sites/cajuscript/deploys)
+
 **Automated Official Website Finder for Business Prospecting**
 
 CajuScript is a Next.js 15 application that automates the search for official company websites using the Google Custom Search API. Upload an Excel spreadsheet with company names, and it returns up to 4 relevant links per company — ready to download as a new spreadsheet.

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
   publish = ".next"
 
 [build.environment]
-  NODE_VERSION = "18.17.0"
+  NODE_VERSION = "18.20.0"
 
 [[plugins]]
   package = "@netlify/plugin-nextjs"


### PR DESCRIPTION
## Problem
Netlify CI builds fail because `netlify.toml` specifies Node 18.17.0, but Next.js 15.1.7 requires Node >= 18.18.0.

## Changes
- **netlify.toml**: Update `NODE_VERSION` from `18.17.0` to `18.20.0` (satisfies Next.js 15 requirements)
- **README.md**: Add Netlify deploy status badge

## Verification
- `pnpm run build` passes locally
- `pnpm run lint` passes with no warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Netlify deploy status badge to the project documentation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ricardo-camilo-programador-frontend-web/cajuscript/pull/9)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->